### PR TITLE
Recovery/one shot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
           }
     
       - name: Run tests
-        run: pytest -q tests
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+        run: pytest -q --confcutdir=. tests
+
 
       - name: Resolve entry script and icon
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,95 @@
-name: CI
-permissions:
-  contents: read
+﻿name: CI
 
 on:
   push:
+    branches: [ main, develop, "feature/**" ]
   pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
 
 jobs:
-  test:
+  test-build:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+        python-version: ["3.10", "3.11", "3.12"]
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
-      - name: Install deps
+      - name: Install deps (editable)
+        shell: pwsh
         run: |
-          python -m pip install -U pip
-          # Install your package (pyproject-based) and pytest
-          python -m pip install -e . pytest
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest build pyinstaller cyclonedx-bom pip-licenses
+
       - name: Run tests
-        env:
-          PYTHONPATH: src
+        run: pytest -q tests
+
+      - name: Resolve entry script and icon
+        shell: pwsh
+        id: resolve
         run: |
-          pytest -q
+          $entry = if (Test-Path "sof_app\ui_qt.py") { "sof_app\ui_qt.py" } elseif (Test-Path "src\sof_app\ui_qt.py") { "src\sof_app\ui_qt.py" } else { "" }
+          if (-not $entry) { throw "ui_qt.py not found in sof_app\ or src\sof_app\" }
+          $icon  = if (Test-Path "sof_app\assets\icons\sof_trefoil.ico") { "sof_app\assets\icons\sof_trefoil.ico" } elseif (Test-Path "src\sof_app\assets\icons\sof_trefoil.ico") { "src\sof_app\assets\icons\sof_trefoil.ico" } else { "" }
+          if (-not $icon) { Write-Host "Icon not found; proceeding without one."; $icon = "" }
+          echo "entry=$entry" >> $env:GITHUB_OUTPUT
+          echo "icon=$icon"   >> $env:GITHUB_OUTPUT
+
+      - name: Build wheel/sdist (once on 3.12)
+        if: matrix.python-version == '3.12'
+        run: python -m build
+
+      - name: Build EXE with PyInstaller (once on 3.12)
+        if: matrix.python-version == '3.12'
+        shell: pwsh
+        run: |
+          $entry = "${{ steps.resolve.outputs.entry }}"
+          $icon  = "${{ steps.resolve.outputs.icon }}"
+          if ($icon) {
+            pyinstaller --noconfirm --clean `
+              --name "SOF-Calculator" `
+              --windowed `
+              --icon "$icon" `
+              "$entry"
+          } else {
+            pyinstaller --noconfirm --clean `
+              --name "SOF-Calculator" `
+              --windowed `
+              "$entry"
+          }
+
+      - name: SBOM + license manifest (build-time only)
+        if: matrix.python-version == '3.12'
+        shell: pwsh
+        run: |
+          python -m cyclonedx_py venv --output-format json -o dist\SBOM.json
+          pip-licenses --with-urls --format=json --output-file dist\THIRD_PARTY_LICENSES.json
+
+      - name: Offline runtime check (no sockets)
+        if: matrix.python-version == '3.12'
+        shell: pwsh
+        run: |
+          if (Test-Path ".\dist\SOF-Calculator\SOF-Calculator.exe") {
+            .\tools\release-verify.ps1 -ExePath ".\dist\SOF-Calculator\SOF-Calculator.exe" -OutDir ".\dist"
+          } else {
+            Write-Host "EXE not found; skipping offline check."
+          }
+
+      - name: Upload artifacts
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sof-dist-${{ github.sha }}
+          path: |
+            dist/**
+            .\dist\SOF-Calculator\SOF-Calculator.exe
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-
+        #
       - name: Install deps (editable)
         shell: pwsh
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+          pip uninstall -y PyQt6 PyQt6-Qt6 PyQt6-sip || $true
+          pip install PySide6
           pip install pytest build pyinstaller cyclonedx-bom pip-licenses
 
+      - name: Offline runtime check (no sockets)
+        if: matrix.python-version == '3.12'
+        shell: pwsh
+        run: |
+          if (Test-Path ".\dist\SOF-Calculator\SOF-Calculator.exe") {
+            .\tools\release-verify.ps1 -ExePath ".\dist\SOF-Calculator\SOF-Calculator.exe" -OutDir ".\dist"
+          } else {
+            Write-Host "EXE not found; skipping offline check."
+          }
+    
       - name: Run tests
         run: pytest -q tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,211 +1,73 @@
-# Byte-compiled / optimized / DLL files
+﻿# Overwrite .gitignore (no BOM)
+$gi = @"
+# --- Python / packaging ---
 __pycache__/
 *.py[cod]
 *$py.class
-
-# C extensions
-*.so
-
-# Runtime outputs
-results/
-
-# Releases & installers
-release/
-*.zip
-*.exe
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
 *.egg-info/
-.installed.cfg
+.eggs/
 *.egg
-MANIFEST
+pip-wheel-metadata/
+.wheels/
+*.whl
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
+# --- Environments ---
+.venv/
+venv/
+ENV/
+env/
+.conda/
+.conda_env/
 
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
+# --- Builds / dists / PyInstaller ---
+build/
+dist/
+*.spec            # PyInstaller spec (uncomment the next line to keep a specific one)
+#!SOF-Calculator.spec
 
-# Unit test / coverage reports
+# --- Test & coverage artifacts ---
+.pytest_cache/
+.coverage
+.coverage.*
 htmlcov/
 .tox/
 .nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-cover/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
-.pdm-python
-.pdm-build/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
+# --- Linters / type checkers / caches ---
 .mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
 .pyre/
-
-# pytype static type analyzer
 .pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Ruff stuff:
 .ruff_cache/
+.cache/
 
-# PyPI configuration file
-.pypirc
+# --- IDE / editor ---
+.vscode/
+.idea/
+*.iml
+*.code-workspace
+.ipynb_checkpoints/
 
-# Cursor  
-#  Cursor is an AI-powered code editor.`.cursorignore` specifies files/directories to 
-#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
-#  refer to https://docs.cursor.com/context/ignore-files
-.cursorignore
-.cursorindexingignore
-# Keep our PyInstaller spec
-!SOF_Method_App.spec
-
-#Arch Tracking
-tree_*.txt
-repo_tree*.txt
-tree_ci*.txt
-tree_data*.txt
-repo_manifest.json
-tree_src*.txt
-tree_tests*.txt
-
-# OS / editor cruft
+# --- OS cruft ---
 .DS_Store
 Thumbs.db
 desktop.ini
-.vscode/
-.idea/
 
-# Extra packaging artifacts
-*.msi
-*.whl  # in case a wheel ever lands outside dist/
+# --- Logs & local outputs ---
+*.log
+logs/
+coverage.xml
+test-results/
+
+# --- Runtime/Release reports (often live in dist/ anyway) ---
+SBOM.json
+THIRD_PARTY_LICENSES.json
+runtime_offline_report.json
+SOF-Calculator.sha256.txt
+
+# --- App local settings (if ever written inside repo) ---
+.sof_app_settings.json
+"@
+$enc = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText(".gitignore", $gi, $enc)
+git add .gitignore
+git commit -m "chore: restore robust .gitignore for Python/PyInstaller/Windows"

--- a/SOF-Calculator.spec
+++ b/SOF-Calculator.spec
@@ -1,0 +1,39 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['src\\sof_app\\ui_qt.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('src\\sof_app\\assets\\icons\\sof_trefoil.ico', 'assets\\icons')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='SOF-Calculator',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['src\\sof_app\\assets\\icons\\sof_trefoil.ico'],
+)

--- a/data/schema/audit_schema.json
+++ b/data/schema/audit_schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SOF Audit Record",
+  "type": "object",
+  "required": ["inputs", "results"],
+  "properties": {
+    "version":   { "type": ["string","null"] },
+    "timestamp": { "type": ["string","null"], "format": "date-time" },
+
+    "inputs": {
+      "type": "object",
+      "required": ["samples_path", "limits_path", "options"],
+      "properties": {
+        "samples_path": { "type": "string" },
+        "limits_path":  { "type": "string" },
+        "alias_path":   { "type": ["string","null"] },
+        "category":     { "type": ["string","null"] },
+        "options": {
+          "type": "object",
+          "required": ["combine_duplicates","treat_missing_as_zero","display_sigfigs","warn_threshold"],
+          "properties": {
+            "combine_duplicates":   { "type": "boolean" },
+            "treat_missing_as_zero":{ "type": "boolean" },
+            "display_sigfigs":      { "type": "integer" },
+            "warn_threshold":        { "type": "number" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+
+    "results": {
+      "type": "object",
+      "required": ["summary"],
+      "properties": {
+        "summary": {
+          "type": "object",
+          "properties": {
+            "sof_total":   { "type": "number" },
+            "pass_limit":  { "type": "boolean" },
+            "margin_to_1": { "type": "number" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/IT-Validation.md
+++ b/docs/IT-Validation.md
@@ -1,0 +1,10 @@
+﻿# IT Validation Playbook — SOF Calculator (Desktop)
+
+**Goal:** Validate supply chain, binary integrity, offline posture, and licensing before distribution.
+
+## SBOM & license (build-time only)
+```powershell
+python -m cyclonedx_py venv --output-format json -o .\dist\SBOM.json
+pip-licenses --with-urls --format=json --output-file .\dist\THIRD_PARTY_LICENSES.json
+
+```

--- a/tests/test_audit_schema_validate.py
+++ b/tests/test_audit_schema_validate.py
@@ -1,0 +1,23 @@
+﻿import os, json, pytest
+try:
+    from jsonschema import Draft7Validator, validate
+except Exception:  # pragma: no cover
+    pytest.skip("jsonschema not installed; run `pip install jsonschema` to enable", allow_module_level=True)
+
+SCHEMA_PATH = os.path.join("data", "schema", "audit_schema.json")
+
+def test_audit_schema_is_valid():
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        schema = json.load(f)
+    Draft7Validator.check_schema(schema)
+
+def test_validate_user_audit_json_if_present():
+    p = os.getenv("SOF_TEST_AUDIT")
+    if not p or not os.path.exists(p):
+        pytest.skip("Set SOF_TEST_AUDIT to path of an audit JSON to validate")
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        schema = json.load(f)
+    with open(p, "r", encoding="utf-8") as f:
+        doc = json.load(f)
+    Draft7Validator.check_schema(schema)
+    validate(doc, schema)

--- a/tests/test_counts_blocked.py
+++ b/tests/test_counts_blocked.py
@@ -1,0 +1,11 @@
+﻿import pytest
+from sof_app.core.units import parse_quantity, convert_to, Q_
+
+def test_counts_units_blocked_parse():
+    for u in ("cpm", "cps", "counts"):
+        with pytest.raises(Exception):
+            parse_quantity(1000, u)
+
+def test_counts_units_blocked_convert():
+    with pytest.raises(Exception):
+        convert_to(Q_(1, "Bq"), "counts")

--- a/tests/test_excel_sof_integration.py
+++ b/tests/test_excel_sof_integration.py
@@ -1,0 +1,20 @@
+﻿import os, pytest
+from sof_app.io.excel_loader import load_samples, load_limits
+from sof_app.services.sof import compute_sof
+
+@pytest.mark.integration
+def test_sof_from_excel_env_paths():
+    samp = os.getenv("SOF_TEST_SAMPLES")
+    lims = os.getenv("SOF_TEST_LIMITS")
+    if not samp or not lims or not os.path.exists(samp) or not os.path.exists(lims):
+        pytest.skip("Set SOF_TEST_SAMPLES and SOF_TEST_LIMITS to valid .csv/.xlsx paths")
+    samples = load_samples(samp)
+    limits  = load_limits(lims)
+    per_nuclide, summary = compute_sof(samples, limits,
+                                       category=None,
+                                       combine_duplicates=True,
+                                       treat_missing_as_zero=True,
+                                       display_sigfigs=4)
+    assert "sof_total" in summary
+    assert isinstance(summary["pass_limit"], (bool,)) or summary["pass_limit"] in (True, False)
+    assert per_nuclide.shape[0] >= 0

--- a/tests/test_surface_norm.py
+++ b/tests/test_surface_norm.py
@@ -1,0 +1,7 @@
+﻿from sof_app.core.units import parse_quantity, convert_to
+
+def test_surface_100cm2_to_m2():
+    # Example: 600 dpm per 100 cm^2 -> 1000 Bq/m^2
+    q = parse_quantity(600, "dpm/100 cm^2")
+    out = convert_to(q, "Bq/m^2")
+    assert abs(out.magnitude - 1000) < 1e-6

--- a/tools/release-verify.ps1
+++ b/tools/release-verify.ps1
@@ -1,0 +1,65 @@
+﻿<#
+.SYNOPSIS
+  Offline posture check: hash + flag ONLY external endpoints (non-loopback).
+#>
+param(
+  [Parameter(Mandatory=$true)][string]$ExePath,
+  [string]$OutDir = "$(Split-Path -Parent $ExePath)\..",
+  [int]$WaitSeconds = 6
+)
+
+$ErrorActionPreference = "Stop"
+$exe = Resolve-Path $ExePath
+if (-not (Test-Path $OutDir)) { New-Item -Type Directory -Force $OutDir | Out-Null }
+$out = Resolve-Path $OutDir
+
+# Hash
+Get-FileHash $exe -Algorithm SHA256 | Tee-Object -FilePath (Join-Path $out "SOF-Calculator.sha256.txt") | Out-Null
+
+# Launch briefly
+$p = Start-Process -FilePath $exe -PassThru
+Start-Sleep -Seconds $WaitSeconds
+
+# Gather
+$tcp_all = Get-NetTCPConnection -OwningProcess $p.Id -ErrorAction SilentlyContinue
+$udp_all = Get-NetUDPEndpoint  -OwningProcess $p.Id -ErrorAction SilentlyContinue
+
+Stop-Process -Id $p.Id -ErrorAction SilentlyContinue
+
+# External-only filters
+$loopbacks = @('127.0.0.1','::1')
+$tcp_external = $tcp_all | Where-Object {
+  $_.State -eq 'Established' -and
+  $_.RemoteAddress -and
+  $_.RemoteAddress -notin $loopbacks -and
+  $_.RemoteAddress -ne '0.0.0.0'
+}
+$udp_external = $udp_all | Where-Object {
+  $_.LocalAddress -and
+  $_.LocalAddress -notin ($loopbacks + @('0.0.0.0','::'))
+}
+
+$report = [pscustomobject]@{
+  exe = $exe.Path
+  timestamp_utc = (Get-Date).ToUniversalTime().ToString("o")
+  summary = [pscustomobject]@{
+    tcp_external_established_count = @($tcp_external).Count
+    udp_external_bound_count       = @($udp_external).Count
+    note = "Loopback-only/unspecified-local bindings allowed; only external endpoints are flagged."
+  }
+  tcp_external_established = $tcp_external | Select LocalAddress,LocalPort,RemoteAddress,RemotePort,State
+  udp_external_bound       = $udp_external | Select LocalAddress,LocalPort
+  tcp_all                  = $tcp_all | Select LocalAddress,LocalPort,RemoteAddress,RemotePort,State
+  udp_all                  = $udp_all | Select LocalAddress,LocalPort
+}
+
+$report | ConvertTo-Json -Depth 6 | Out-File (Join-Path $out "runtime_offline_report.json") -Encoding utf8
+
+# hard fail if any external endpoint seen
+if (@($tcp_external).Count -gt 0 -or @($udp_external).Count -gt 0) {
+  Write-Error "External network endpoints detected. See runtime_offline_report.json."
+  exit 1
+} else {
+  Write-Host "Offline posture OK (no external endpoints)."
+  exit 0
+}


### PR DESCRIPTION
## What’s in this PR
- CI: use `python -m cyclonedx_py venv` for SBOM + `pip-licenses` manifest.
- Packaging: PySide6-only build (remove PyQt6 in CI); PyInstaller bundles app icon.
- Security: offline runtime verifier (`tools/release-verify.ps1`) hashes EXE and fails on external sockets.
- Tests: counts-unit blocking; dpm/100 cm² → Bq/m² normalization; pytest confined to `tests/`.
- Docs: IT-Validation playbook (SBOM/license, offline check, optional audits).
- Hygiene: restore robust `.gitignore`.

## Acceptance
- [ ] CI passes on Windows (3.12).
- [ ] `dist/SOF-Calculator.exe` produced with icon.
- [ ] `dist/runtime_offline_report.json` summary shows zero external endpoints.
- [ ] SBOM (`dist/SBOM.json`) and license manifest (`dist/THIRD_PARTY_LICENSES.json`) present.

Notes: App remains fully offline at runtime; screening-level engineering tool.
